### PR TITLE
Allow to run systemctl inside ubuntu image

### DIFF
--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -1,8 +1,15 @@
 FROM ubuntu:16.04
 
-MAINTAINER Andrea Tosatto <andrea@tosatto.me>
+LABEL maintainer "Andrea Tosatto <andrea@tosatto.me>"
 
 # Install some extra packages
-RUN apt-get update -y \
-  && apt-get install -y iproute2 \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get dist-upgrade --yes --force-yes && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    iproute2 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/sbin/init"]


### PR DESCRIPTION
This change introduce the below changes:
* allow to run ansible playbooks which requires `systemctl` command
* upgrade packages to the latest one, since almost all ansible
  playbooks run `dist-upgrade`
* Update MAINTAINER section, which is deprecated for the latest
  Docker